### PR TITLE
ploigos-tool-sonar - update to be based on java base so has access to keytool to deal with CA trust stuff

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -923,7 +923,7 @@ jobs:
   ######################
   ploigos-tool-sonar:
     needs:
-    - ploigos-base
+    - ploigos-base-java-8
 
     runs-on: ubuntu-latest
 
@@ -932,7 +932,7 @@ jobs:
       IMAGE_FILE: Containerfile
       IMAGE_NAME: ploigos-tool-sonar
       IMAGE_TAG_LOCAL: localhost:5000/${{ secrets.REGISTRY_REPOSITORY }}/ploigos-tool-sonar:latest
-      FROM_IMAGE_NAME: ploigos-base
+      FROM_IMAGE_NAME: ploigos-base-java-8
 
     services:
       registry:

--- a/ploigos-base/Containerfile.ubi8
+++ b/ploigos-base/Containerfile.ubi8
@@ -65,6 +65,9 @@ RUN useradd ploigos --uid $PLOIGOS_USER_UID --gid $PLOIGOS_USER_GID --home-dir $
     chown -R $PLOIGOS_USER_UID:${PLOIGOS_USER_GID} ${PLOIGOS_HOME_DIR} && \
     chmod -R g+w ${PLOIGOS_HOME_DIR}
 
+# allow root(0) group to run update-ca-trust extract
+RUN chmod -R g+w /etc/pki/ca-trust/extracted
+
 USER $PLOIGOS_USER_UID
 ##############################################
 # End

--- a/ploigos-tool-sonar/Containerfile.ubi8
+++ b/ploigos-tool-sonar/Containerfile.ubi8
@@ -1,4 +1,5 @@
-ARG FROM_IMAGE=quay.io/ploigos/ploigos-base:latest
+# NOTE: from Java so can have access to keytool
+ARG FROM_IMAGE=quay.io/ploigos/ploigos-base-java-8:latest
 
 FROM $FROM_IMAGE
 ARG PLOIGOS_USER_UID


### PR DESCRIPTION
# purpose

need `keytool` in sonar image so can add trusted CAs dynamically. so base sonar on java to get `keytool`
