### PR TITLE
WIP: Create ploigos-jenkins-plugins to bundle plugins for disconnected environments

### DIFF
--- a/ploigos-jenkins-plugins/Containerfile
+++ b/ploigos-jenkins-plugins/Containerfile
@@ -1,0 +1,1 @@
+Containerfile.ubi8

--- a/ploigos-jenkins-plugins/Containerfile.ubi8
+++ b/ploigos-jenkins-plugins/Containerfile.ubi8
@@ -1,0 +1,26 @@
+# use the existing Jenkins image so we have access to the install-plugins
+# script. It also lets us avoid pulling down dependencies that are already in
+# the base image
+FROM registry.redhat.io/openshift4/ose-jenkins:latest AS jenkins
+
+USER root
+
+# fetch the container images
+COPY ./ploigos-plugins.txt /tmp/ploigos-plugins.txt
+RUN /usr/local/bin/install-plugins.sh /tmp/ploigos-plugins.txt
+
+# delete the symlinks
+# rename *.hpi to *.jpi, since Jenkins expects this
+# copy everything into /usr/lib/jenkins so we can grab it for the final image.
+RUN find /opt/openshift/plugins -type l -delete && \
+    for f in /usr/lib/jenkins/*.hpi ; do mv -v $f /usr/lib/jenkins/$(basename $f ".hpi").jpi ; done && \
+    cp -v /opt/openshift/plugins/* /usr/lib/jenkins/
+
+# shift to a ubi-minimal image, copy in the plugins that were installed above.
+# this leaves us with a minimal image with just the plugins.
+FROM registry.redhat.io/ubi8/ubi-minimal:latest
+
+USER 1001
+
+# copy the artifacts from the previous image
+COPY --from=jenkins /usr/lib/jenkins /ploigos-jenkins-plugins

--- a/ploigos-jenkins-plugins/README.md
+++ b/ploigos-jenkins-plugins/README.md
@@ -1,0 +1,26 @@
+# ploigos-jenkins-plugins
+
+This container image contains the set of Jenkins plugins and dependencies that Ploigos workflows require.
+
+This container image can be installed as an initContainer that copies plugins into `$JENKINS_HOME/plugins` on
+startup. For persistent Jenkins deployments, mount the Jenkins PV into the init container so the copying can
+occur.
+
+Example:
+```
+      initContainers:
+        - name: ploigos-plugins
+          command:
+            - /bin/bash
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: jenkins-data
+              mountPath: /var/lib/jenkins
+          image: >-
+            registry.gpslab.cbr.redhat.com/redhatgov/ploigos-jenkins-plugins:latest
+          args:
+            - '-c'
+            - >-
+              mkdir -p /var/lib/jenkins/plugins ; cp --remove-destination -v
+              /ploigos-jenkins-plugins/* /var/lib/jenkins/plugins
+```

--- a/ploigos-jenkins-plugins/ploigos-plugins.txt
+++ b/ploigos-jenkins-plugins/ploigos-plugins.txt
@@ -1,0 +1,2 @@
+gitea:1.2.1
+ansicolor:0.7.3


### PR DESCRIPTION
I've got this as a WIP for initial review and feedback. My testing so far has been positive but I still have more to do. I figure if this container goes in first and is built, then a follow-up PR can go into the Ploigos operator to change the Jenkins DC to include it as an initContainer.

---

This container is built with a two-stage process. The first uses the existing Jenkins image so as to use the
install-plugins.sh script to pull down the plugins listed in ploigos-plugins.txt. The second stage copies all
of these plugins into a ubi-minimal container.

The container can then be used as an initContainer for a Jenkins deployment, with the Jenkins PV mounted into
the container. The content can then be copied into $JENKINS_HOME/plugins.

This container can then be shipped into disconnected environments to provide all the required plugins to
support Ploigos deployment.