### PR TITLE
auto build ploigos-tool-openscap on ubi8 now that openscap is in ubi app stream repos

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1256,6 +1256,106 @@ jobs:
       - name: Image Digest 🔖
         run: echo ${{ steps.image_build.outputs.digest }}
 
+  ################################
+  # ploigos-tool-openscap_ubi8#
+  ################################
+  ploigos-tool-openscap_ubi8:
+    needs:
+    - ploigos-tool-containers_ubi8
+
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE_CONTEXT: ./ploigos-tool-openscap
+      IMAGE_FILE: Containerfile.ubi8
+      IMAGE_NAME: ploigos-tool-openscap
+      IMAGE_TAG_LOCAL: localhost:5000/${{ secrets.REGISTRY_REPOSITORY }}/ploigos-tool-openscap:latest.ubi8
+      IMAGE_TAG_FLAVOR: .ubi8
+      IMAGE_IS_DEFAULT_FLAVOR: true
+      BASE_IMAGE_NAME: ploigos-tool-containers
+
+    services:
+      registry:
+        image: registry:2
+        ports:
+        - 5000:5000
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+
+      - name: Determine Image Version and Tags ⚙️
+        id: prep
+        run: ${GITHUB_WORKSPACE}/.github/scripts/determine-image-version.sh
+
+      - name: Version 📌
+        run: echo ${{ steps.prep.outputs.version }}
+
+      - name: Image Tags 🏷
+        run: echo ${{ steps.prep.outputs.tags }}
+
+      - name: Set up QEMU 🧰
+        uses: docker/setup-qemu-action@v1.0.1
+
+      - name: Set up Docker Buildx 🧰
+        uses: docker/setup-buildx-action@v1.0.4
+        with:
+          driver-opts: network=host
+
+      - name: Cache Docker layers 🗃
+        uses: actions/cache@v2.1.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Image 🛠
+        id: image_build
+        uses: docker/build-push-action@v2.2.1
+        env:
+          IMAGE_BUILD_ARGS: BASE_IMAGE=${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}/${{ env.BASE_IMAGE_NAME }}:${{ steps.prep.outputs.version }}
+        with:
+          context: ${{ env.IMAGE_CONTEXT }}
+          file: ${{ env.IMAGE_CONTEXT }}/${{ env.IMAGE_FILE }}
+          build-args: ${{ env.IMAGE_BUILD_ARGS }}
+          push: true
+          tags: ${{ env.IMAGE_TAG_LOCAL }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Test Image 🧪
+        run: |
+          echo "test oscap"
+          docker run -u 1001 ${{ env.IMAGE_TAG_LOCAL }} oscap --version
+
+      - name: Login to External Registry 🔑
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.REGISTRY_URI }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push to External Registry 🔺
+        id: push
+        run: |
+          docker pull ${{ env.IMAGE_TAG_LOCAL }}
+
+          TAGS=${{ steps.prep.outputs.tags }}
+          for TAG in ${TAGS//,/ }; do
+            docker tag ${{ env.IMAGE_TAG_LOCAL }} ${TAG}
+            docker push ${TAG}
+          done
+
+      - name: Image Digest 🔖
+        run: echo ${{ steps.image_build.outputs.digest }}
+
 ## CENTOS ##
 
   #######################
@@ -1486,11 +1586,11 @@ jobs:
 
     env:
       IMAGE_CONTEXT: ./ploigos-tool-openscap
-      IMAGE_FILE: Containerfile.ubi8
+      IMAGE_FILE: Containerfile.centos
       IMAGE_NAME: ploigos-tool-openscap
-      IMAGE_TAG_LOCAL: localhost:5000/${{ secrets.REGISTRY_REPOSITORY }}/ploigos-tool-openscap:latest
+      IMAGE_TAG_LOCAL: localhost:5000/${{ secrets.REGISTRY_REPOSITORY }}/ploigos-tool-openscap:latest.centos
       IMAGE_TAG_FLAVOR: .centos
-      IMAGE_IS_DEFAULT_FLAVOR: true
+      IMAGE_IS_DEFAULT_FLAVOR: false
       BASE_IMAGE_NAME: ploigos-tool-containers
 
     services:


### PR DESCRIPTION
# context

openscap was not previously in the ubi app stream repos so an openscap tool image on ubi8 could not be built without a subcription. openscap is now in the ubi app stream making this possible.

# purpose

auto build the openscap ubi8 image.