### PR TITLE
upgrade to argocd v2.0.4 for all the fancy new fixes, most importantly automatically switching to grpc-web when needed

### DIFF
--- a/ploigos-tool-argocd/Containerfile.ubi8
+++ b/ploigos-tool-argocd/Containerfile.ubi8
@@ -1,7 +1,9 @@
 ARG BASE_IMAGE=quay.io/ploigos/ploigos-base:latest.ubi8
+ARG ARGOCD_VERSION=v2.0.4
 
 FROM $BASE_IMAGE
 ARG PLOIGOS_USER_UID
+ARG ARGOCD_VERSION
 
 # labels
 ENV DESCRIPTION="Ploigos tool container with ArgoCD cli"
@@ -24,7 +26,7 @@ USER root
 #       see https://github.com/containers/buildah/issues/2345
 #       Once this is resolved, store the path to the argocd cli in argument so it can be overwritten
 #		without rebuilding the image.
-RUN curl -L https://github.com/argoproj/argo-cd/releases/download/v1.6.1/argocd-linux-amd64 -o /usr/bin/argocd && \
+RUN curl -L https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64 -o /usr/bin/argocd && \
     chmod 775 /usr/bin/argocd && chown 1001:0 /usr/bin/argocd
 
 # may not actually be able to run as this user at runtime


### PR DESCRIPTION
# purpose

* our argocd cli version is old
* newer version will automatically swithc to grpc-web mode when needed, which is important if using OpenShift route with edge TLS termination in front of ArgoCD
