### PR TITLE
lock rekor cli to version that works with psr v0.19.0

### DIFF
--- a/ploigos-tool-autogov/Containerfile.ubi8
+++ b/ploigos-tool-autogov/Containerfile.ubi8
@@ -1,7 +1,11 @@
 ARG BASE_IMAGE=quay.io/ploigos/ploigos-base:latest.ubi8
+ARG REKOR_VERSION=e63fe717c810657c270edfb964aef10969e7f210
+ARG OPA_VERSION=v0.29.4
 
 FROM $BASE_IMAGE
 ARG PLOIGOS_USER_UID
+ARG REKOR_VERSION
+ARG OPA_VERSION
 
 # labels
 ENV DESCRIPTION="Ploigos tool container with Rekor and Open Policy Agent."
@@ -34,8 +38,12 @@ RUN INSTALL_PKGS="golang" && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Install rekor
+# NOTE: better way to install, except as of 7/21/21 only v0.2.0 is released and it doesnt work with PSR
+#RUN curl -L https://github.com/sigstore/rekor/releases/download/${REKOR_VERSION}/rekor-cli -o /usr/bin/rekor && \
+#    chmod +x /usr/bin/rekor
 RUN git clone https://github.com/sigstore/rekor.git && \
     cd rekor && \
+    git checkout ${REKOR_VERSION} && \
     go build ./cmd/rekor-cli && \
     mv rekor-cli /usr/local/bin/rekor && \
     chmod 775 /usr/bin && \
@@ -43,9 +51,8 @@ RUN git clone https://github.com/sigstore/rekor.git && \
     chown 1001:0 /usr/local/bin/rekor
 
 #Install opa
-RUN curl -L -o opa https://openpolicyagent.org/downloads/v0.29.4/opa_linux_amd64 && \
-    chmod 775 ./opa && \
-    mv opa /usr/bin/
+RUN curl -L https://openpolicyagent.org/downloads/${OPA_VERSION}/opa_linux_amd64 -o /usr/bin/opa && \
+    chmod +x /usr/bin/opa
 
 # may not actually be able to run as this user at runtime
 # but platforms like OpenShift will still respect users home directory


### PR DESCRIPTION
# purpose

currently installking rekor from main branch which causes problems as its quick reving and the entry format seems to be changing and breaking the PSR.

# testing

## e63fe717c810657c270edfb964aef10969e7f210 (works)

this was the latest commit i could find (though i didn't look hard) that works with psr v0.19.0

## v0.2.0 (NO WORK)
v0.2.0 of rekor cli doesnt work with v0.19.0 PSR get following error:
```
  RAN: /usr/bin/rekor upload --rekor_server https://rekor.apps.tssc.rht-set.com/ --entry /home/jenkins/agent/workspace/hing_reference-quarkus-mvn_PR-23/step-runner-working/generate-evidence/entry.json

  STDOUT:
panic: interface conversion: interface {} is *strfmt.URI, not strfmt.URI

goroutine 1 [running]:
github.com/sigstore/rekor/pkg/generated/client/entries.(*CreateLogEntryCreated).readResponse(0xc0000ba240, 0xd0ad78, 0xc000122480, 0xcfd100, 0xc51e68, 0xd0efa8, 0xc0002ee1e0, 0x0, 0x0)
	/home/luke/go/src/github.com/lukehinds/rekor/pkg/generated/client/entries/create_log_entry_responses.go:121 +0x328
github.com/sigstore/rekor/pkg/generated/client/entries.(*CreateLogEntryReader).ReadResponse(0xc000458ae0, 0xd0ad78, 0xc000122480, 0xcfd100, 0xc51e68, 0x1, 0x0, 0x0, 0x0)
	/home/luke/go/src/github.com/lukehinds/rekor/pkg/generated/client/entries/create_log_entry_responses.go:45 +0x410
github.com/go-openapi/runtime/client.(*Runtime).Submit(0xc00045b110... (1446 more, please see e.stdout)
```