### PR TITLE
default the podman/buildah/skopeo storage driver to VFS

### DIFF
--- a/ploigos-tool-containers/Containerfile.ubi8
+++ b/ploigos-tool-containers/Containerfile.ubi8
@@ -45,10 +45,8 @@ RUN chmod g+rw /etc/subgid /etc/subuid
 # so still worth setting
 USER $PLOIGOS_USER_UID
 
-# Set up environment variables to note that this is
-# not starting with usernamespace and default to
-# isolate the filesystem with chroot.
-ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
+# set up environment variables for use by podman/buildah/skopeo to be able to run as rootless
+ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot STORAGE_DRIVER="vfs"
 
 # set custom entrypoint which also calls the base entrypoint
 COPY ploigos-tool-containers-entrypoint.sh /

--- a/ploigos-tool-jkube/Containerfile.ubi8
+++ b/ploigos-tool-jkube/Containerfile.ubi8
@@ -45,10 +45,11 @@ RUN chmod g+rw /etc/subgid /etc/subuid
 # so still worth setting
 USER $PLOIGOS_USER_UID
 
-# Set up environment variables to note that this is
-# not starting with usernamespace and default to
-# isolate the filesystem with chroot.
-ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
+# set up environment variables for use by podman/buildah/skopeo to be able to run as rootless
+ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot STORAGE_DRIVER="vfs"
+
+# set up environment variables for podman service to be used by jkube
+ENV DOCKER_HOST="unix:/home/ploigos/podman.sock"
 
 # set custom entrypoint which also calls the base entrypoint
 COPY ploigos-tool-jkube-entrypoint.sh /

--- a/ploigos-tool-jkube/ploigos-tool-jkube-entrypoint.sh
+++ b/ploigos-tool-jkube/ploigos-tool-jkube-entrypoint.sh
@@ -7,7 +7,6 @@ echo $(whoami):10000:65536 >> /etc/subgid
 
 # create a podman socket for JKube to use
 # SEE https://github.com/fabric8io/docker-maven-plugin/issues/1330#issuecomment-872905283
-export DOCKER_HOST="unix:/home/ploigos/podman.sock"
 podman system service --time=0 ${DOCKER_HOST} 1> /home/ploigos/podman.stdout 2> /home/ploigos/podman.stderr &
 
 # call the base entrypoint


### PR DESCRIPTION
# Purpose

default the podman/buildah/skopeo storage driver to VFS because iss what works in rootless mode.

NOTE: brand new kernels can support rootless overlay but it isn't wide spread enough yet to be useful, but when it is can be overriden with env var and the default can be changed when it makes sense

This also fixes bug where needed the podman socket in jkube to be set to the same storage driver as the podman commands run in other steps which are currently hard coded to vfs.

# related / dependent on
* https://github.com/ploigos/ploigos-step-runner/pull/175

# integration testing
## jenkins
 - [x] [minimum](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(minimal)/job/reference-quarkus-mvn/view/change-requests/job/PR-26/3/)
  - [x] [typical](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(typical)/job/reference-quarkus-mvn/view/change-requests/job/PR-26/3/) 
  - [x] [everything](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(everything)/job/reference-quarkus-mvn/view/change-requests/job/PR-26/3/)