### PR TITLE
plogios-tool-cypress - init add

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2212,3 +2212,107 @@ jobs:
 
       - name: Image Digest 🔖
         run: echo ${{ steps.image_build.outputs.digest }}
+
+  ##################################
+  # ploigos-tool-cypress_ubi8      #
+  ##################################
+  ploigos-tool-cypress_ubi8:
+    needs:
+    - ploigos-base_ubi8
+
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE_CONTEXT: ./ploigos-tool-cypress
+      IMAGE_FILE: Containerfile.ubi8
+      IMAGE_NAME: ploigos-tool-cypress
+      IMAGE_TAG_LOCAL: localhost:5000/${{ secrets.REGISTRY_REPOSITORY }}/ploigos-tool-cypress:latest.ubi8
+      BASE_IMAGE_NAME: ploigos-base
+      IMAGE_TAG_FLAVOR: .ubi8
+      IMAGE_IS_DEFAULT_FLAVOR: true
+
+    services:
+      registry:
+        image: registry:2
+        ports:
+        - 5000:5000
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+
+      - name: Determine Image Version and Tags ⚙️
+        id: prep
+        run: ${GITHUB_WORKSPACE}/.github/scripts/determine-image-version.sh
+
+      - name: Version 📌
+        run: echo ${{ steps.prep.outputs.version }}
+
+      - name: Image Tags 🏷
+        run: echo ${{ steps.prep.outputs.tags }}
+
+      - name: Set up QEMU 🧰
+        uses: docker/setup-qemu-action@v1.0.1
+
+      - name: Set up Docker Buildx 🧰
+        uses: docker/setup-buildx-action@v1.0.4
+        with:
+          driver-opts: network=host
+
+      - name: Cache Docker layers 🗃
+        uses: actions/cache@v2.1.3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Image 🛠
+        id: image_build
+        uses: docker/build-push-action@v2.2.1
+        env:
+          IMAGE_BUILD_ARGS: BASE_IMAGE=${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}/${{ env.BASE_IMAGE_NAME }}:${{ steps.prep.outputs.version }}
+        with:
+          context: ${{ env.IMAGE_CONTEXT }}
+          file: ${{ env.IMAGE_CONTEXT }}/${{ env.IMAGE_FILE }}
+          build-args: ${{ env.IMAGE_BUILD_ARGS }}
+          push: true
+          tags: ${{ env.IMAGE_TAG_LOCAL }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Test Image 🧪
+        run: |
+          echo "Running: docker run --entrypoint=which ${{ env.IMAGE_TAG_LOCAL }} node npm google-chrome cypress"
+          docker run --entrypoint=which ${{ env.IMAGE_TAG_LOCAL }} npm
+          docker run --entrypoint=which ${{ env.IMAGE_TAG_LOCAL }} node
+          docker run --entrypoint=which ${{ env.IMAGE_TAG_LOCAL }} google-chrome
+          docker run --entrypoint=which ${{ env.IMAGE_TAG_LOCAL }} cypress
+
+      - name: Login to External Registry 🔑
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.REGISTRY_URI }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push to External Registry 🔺
+        id: push
+        run: |
+          docker pull ${{ env.IMAGE_TAG_LOCAL }}
+
+          TAGS=${{ steps.prep.outputs.tags }}
+          for TAG in ${TAGS//,/ }; do
+            docker tag ${{ env.IMAGE_TAG_LOCAL }} ${TAG}
+            docker push ${TAG}
+          done
+
+      - name: Image Digest 🔖
+        run: echo ${{ steps.image_build.outputs.digest }}
+

--- a/ploigos-tool-cypress/Containerfile
+++ b/ploigos-tool-cypress/Containerfile
@@ -1,0 +1,1 @@
+Containerfile.ubi8

--- a/ploigos-tool-cypress/Containerfile.ubi8
+++ b/ploigos-tool-cypress/Containerfile.ubi8
@@ -1,0 +1,176 @@
+ARG BASE_IMAGE=quay.io/ploigos/ploigos-base:latest.ubi8
+ARG NODEJS_STREAM=14
+ARG NODEJS_PROFILE=common
+
+FROM $BASE_IMAGE
+ARG PLOIGOS_USER_UID
+ARG NODEJS_STREAM
+ARG NODEJS_PROFILE
+
+# labels
+ENV DESCRIPTION="Ploigos tool container with javascript and cypress CLI."
+LABEL \
+    maintainer="Ploigos <ploigos@redhat.com>" \
+    name="ploigos/ploigos-tool-cypress" \
+    summary="$DESCRIPTION" \
+    description="$DESCRIPTION" \
+    License="GPLv2+" \
+    architecture="x86_64" \
+    io.k8s.display-name="Ploigos - Tool - javascript - cypress" \
+    io.k8s.description="$DESCRIPTION" \
+    io.openshift.expose-services="" \
+    io.openshift.tags="ploigos,javascript,cypress" \
+    com.redhat.component="ploigos-tool-cypress-container"
+
+USER root
+
+## Install node/npm
+RUN dnf update -y --allowerasing --nobest && \
+    dnf module install -y --setopt=tsflags=nodocs nodejs:${NODEJS_STREAM}/${NODEJS_PROFILE} && \
+    dnf clean all && \
+    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+##
+## Install dependencies
+## From official Cypress documentation: xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib
+## But for now using this as a guide: https://github.com/cypress-io/cypress-docker-images/blob/master/base/centos7-12.4.0/Dockerfile
+
+RUN yum update
+RUN yum install -y gcc-c++ make
+RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash -
+
+RUN yum install -y yum-utils
+RUN yum-config-manager --add-repo http://ftp.heanet.ie/pub/centos/8/AppStream/x86_64/os/
+RUN yum install -y xorg-x11-server-Xvfb --nogpgcheck
+#RUN yum install -y xorg-x11-xauth --nogpgcheck
+RUN yum-config-manager --disable ftp.heanet.ie_pub_centos_8_AppStream_x86_64_os_
+
+# note:
+#   Gtk2 for Cypress < 3.3.0
+#   Gtk3 for Cypress >= 3.3.0
+RUN yum install -y gtk2-2.24*
+RUN yum install -y gtk3-3.22*
+RUN yum install -y libXtst*
+# provides libXss
+RUN yum install -y libXScrnSaver*
+# provides libgconf-2
+RUN yum install -y GConf2*
+# provides libasound
+RUN yum install -y alsa-lib*
+
+RUN npm install yarn -g
+
+# there is some dependency I cannot figure out missing
+# which gets installed when installing "git*"
+RUN yum install -y git*
+
+# ########## END Dependencies Install ###########
+
+
+##
+## Install google chrome and its needed dependencies
+##
+RUN yum-config-manager --add-repo http://ftp.heanet.ie/pub/centos/8/BaseOS/x86_64/os/
+RUN yum install -y liberation-fonts --nogpgcheck
+RUN yum-config-manager --disable ftp.heanet.ie_pub_centos_8_BaseOS_x86_64_os_
+
+RUN yum-config-manager --add-repo http://ftp.heanet.ie/pub/centos/8/AppStream/x86_64/os/
+RUN yum install -y xdg-utils --nogpgcheck
+RUN yum install -y vulkan-loader --nogpgcheck
+RUN yum-config-manager --disable ftp.heanet.ie_pub_centos_8_AppStream_x86_64_os_
+
+## install Chrome browser
+RUN yum install -y wget
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
+RUN yum localinstall -y google-chrome-stable_current_*.rpm --nogpgcheck
+RUN rm -rf google-chrome-stable_current_*.rpm
+
+# ########## END Chrome Install ###########
+
+
+## a few environment variables to make NPM installs easier
+## good colors for most applications
+ENV TERM xterm
+## avoid million NPM install messages
+ENV npm_config_loglevel warn
+## allow installing when the main user is root
+ENV npm_config_unsafe_perm true
+
+
+##
+## Install Cypress CLI ??
+##
+
+
+# # Update the dependencies to get the latest and greatest (and safest!) packages.
+# RUN apt update && apt upgrade -y
+
+# # avoid too many progress messages
+# # https://github.com/cypress-io/cypress/issues/1243
+ENV CI=1
+
+# # disable shared memory X11 affecting Cypress v4 and Chrome
+# # https://github.com/cypress-io/cypress-docker-images/issues/270
+ENV QT_X11_NO_MITSHM=1
+ENV _X11_NO_MITSHM=1
+ENV _MITSHM=0
+
+# # should be root user
+# RUN echo "whoami: $(whoami)"
+# RUN npm config -g set user $(whoami)
+
+# # command "id" should print:
+# # uid=0(root) gid=0(root) groups=0(root)
+# # which means the current user is root
+# RUN id
+
+# point Cypress at the /root/cache no matter what user account is used
+# see https://on.cypress.io/caching
+
+ENV CYPRESS_CACHE_FOLDER=/root/.cache/Cypress
+RUN npm install -g "cypress@7.7.0"
+RUN cypress verify
+
+# Cypress cache and installed version
+# should be in the root user's home folder
+RUN cypress cache path
+RUN cypress cache list
+RUN cypress info
+RUN cypress version
+
+# give every user read access to the "/root" folder where the binary is cached
+# we really only need to worry about the top folder, fortunately
+RUN ls -la /root
+RUN chmod 755 /root
+
+# # always grab the latest Yarn
+# # otherwise the base image might have old versions
+# # NPM does not need to be installed as it is already included with Node.
+# RUN npm i -g yarn@latest
+
+# # Show where Node loads required modules from
+# RUN node -p 'module.paths'
+
+# should print Cypress version
+# plus Electron and bundled Node versions
+RUN cypress version
+
+
+# ENTRYPOINT ["cypress", "run"]
+
+# ########## END Cypress Install ###########
+
+
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "rhel version:  $(cat /etc/redhat-release) \n" \
+  "chrome version:  $(google-chrome --version) \n" \
+  "user:            $(whoami) \n"
+
+# # may not actually be able to run as this user at runtime
+# # but platforms like OpenShift will still respect users home directory
+# # so still worth setting
+# USER ${PLOIGOS_USER_UID}

--- a/ploigos-tool-cypress/README.md
+++ b/ploigos-tool-cypress/README.md
@@ -1,0 +1,9 @@
+# ploigos-tool-javascript
+
+This repository contains the container definition for creating the Ploigos workflow
+javascript with [Nodejs](https://www.nodejs.org/) and [NPM](https://www.npmjs.com/) CLI tool container image and [Cypress](https://cypress.io) and its dependencies.
+
+This container image is intended to be used as the container image to run Ploigos workflow steps
+in that require access to the [Nodejs](https://www.nodejs.org/) and [NPM](https://www.npmjs.com/) and [Cypress](https://cypress.io) CLI tools.
+
+Based on Image (https://github.com/cypress-io/cypress-docker-images/blob/master/base/centos7-12.4.0/Dockerfile) adapted for RHEL8


### PR DESCRIPTION
#### What is this PR About?
Describe the contents of the PR

This containerfile is for all dependencies needed to run Cypress on RHEL8. It does require some X11 libraries and added Chrome as well (that might not be needed depending on the tests we run).

I add repos from a mirror that I found, but can certainly move to a more official one.

This image does not install Cypress CLI yet. The cypress tool itself gets installed during >npm install / ci and then runs with the local script >npm run test:integration-local



