### PR TITLE
Add node to sonar scanner

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1475,7 +1475,7 @@ jobs:
   ###########################
   ploigos-tool-sonar_ubi8:
     needs:
-    - ploigos-base_ubi8
+    - ploigos-tool-javascript_ubi8
 
     runs-on: ubuntu-latest
 
@@ -1486,8 +1486,8 @@ jobs:
       IMAGE_TAG_LOCAL: localhost:5000/${{ secrets.REGISTRY_REPOSITORY }}/ploigos-tool-sonar:latest.ubi8
       IMAGE_TAG_FLAVOR: .ubi8
       IMAGE_IS_DEFAULT_FLAVOR: true
-      BASE_IMAGE_NAME: ploigos-base
-      BASE_IMAGE_VERSION: ${{ needs.ploigos-base_ubi8.outputs.version }}
+      BASE_IMAGE_NAME: ploigos-tool-javascript
+      BASE_IMAGE_VERSION: ${{ needs.ploigos-tool-javascript_ubi8.outputs.version }}
 
     services:
       registry:
@@ -1552,6 +1552,8 @@ jobs:
         run: |
           echo "Running: docker run ${{ env.IMAGE_TAG_LOCAL }} sonar-scanner --version"
           docker run -u 1001 ${{ env.IMAGE_TAG_LOCAL }} sonar-scanner --version
+          echo "Running: docker run ${{ env.IMAGE_TAG_LOCAL }} node -v"
+          docker run -u 1001 ${{ env.IMAGE_TAG_LOCAL }} node -v
 
       - name: Login to External Registry 🔑
         uses: docker/login-action@v1

--- a/ploigos-tool-sonar/Containerfile.ubi8
+++ b/ploigos-tool-sonar/Containerfile.ubi8
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/ploigos/ploigos-base:latest.ubi8
+ARG BASE_IMAGE=quay.io/ploigos/ploigos-tool-javascript:latest.ubi8
 
 FROM $BASE_IMAGE
 ARG PLOIGOS_USER_UID


### PR DESCRIPTION
# Purpose
In order to perform SonarQube static code analysis on javascript-based projects, the ploigos-tool-sonar container must have access to the `node` command.

# Breaking?
Yes. (Note - this update will not break any existing functionality)

## Whats Breaking and why?
When scanning javascript based projects using nodejs, the sonar scanner client attempts to run the `node` command. If it is not available,  the scan completes however no files are analyzed.

```
...
INFO: Sensor SonarCSS Rules [cssfamily]
        ERROR: CSS rules were not executed. Error when running: 'node -v'. Is Node.js available during analysis?
...
 INFO: Using TypeScript at: '/home/jenkins/agent/workspace/tform_nc-covidsafe-ui_...'
        ERROR: Error when running: 'node -v'. Is Node.js available during analysis?
```

# Integration Testing
(Performed in private environment)

