### PR TITLE
Update maven version to 3.8.4. 3.8.3 can no longer be downloaded from…

### DIFF
--- a/ploigos-tool-maven/Containerfile.ubi8
+++ b/ploigos-tool-maven/Containerfile.ubi8
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=quay.io/ploigos/ploigos-tool-java-8:latest.ubi8
-ARG MAVEN_VERSION=3.8.3
+ARG MAVEN_VERSION=3.8.4
 
 FROM $BASE_IMAGE
 ARG PLOIGOS_USER_UID


### PR DESCRIPTION
# Purpose
The image build fails for the maven image because curl cannot find the maven archive at the provided url, because version 3.8.3 is no longer available for download at the given location. Bumping the version to 3.8.4 fixes that.

# Breaking?
No