### PR TITLE
maven 3.8.4 no longer available, update to 3.8.5

### DIFF
--- a/ploigos-tool-maven/Containerfile.ubi8
+++ b/ploigos-tool-maven/Containerfile.ubi8
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=quay.io/ploigos/ploigos-tool-java-8:latest.ubi8
-ARG MAVEN_VERSION=3.8.4
+ARG MAVEN_VERSION=3.8.5
 
 FROM $BASE_IMAGE
 ARG PLOIGOS_USER_UID


### PR DESCRIPTION
# Purpose
maven 3.8.4 no longer avaialble.

# Breaking?
hopefully no. that would be on maven.

# Integration Testing
yolo