### PR TITLE
Upgrade ploigos-base to python 3.9

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,8 @@ on:
     tags:
     - 'v*.*.*'
   pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 env:
   GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}

--- a/ploigos-base/Containerfile.ubi8
+++ b/ploigos-base/Containerfile.ubi8
@@ -59,14 +59,15 @@ RUN curl -L https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_l
     chmod +x /usr/bin/yq
 
 # Install packages
-RUN INSTALL_PKGS="gettext git rsync tar unzip which zip bzip2 python36 python3-pip python3-pip-wheel python3-setuptools python36-devel ${SOPS_RPM} gnupg2" && \
+RUN INSTALL_PKGS="gettext git rsync tar unzip which zip bzip2 python39 python39-pip python39-pip-wheel python3-setuptools python36-devel ${SOPS_RPM} gnupg2" && \
+    dnf module enable -y python39:3.9 && \
     dnf update -y --allowerasing --nobest && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Configure Python
-RUN alternatives --set python /usr/bin/python3 && \
+RUN alternatives --set python /usr/bin/python3.9 && \
     python -m pip install --no-cache-dir --upgrade pip
 
 # Install Ploigos step runner python library


### PR DESCRIPTION
# Purpose
PSR no longer supports python 3.6. The latest supported version is currently 3.9. Let's upgrade.

# Breaking?
No

# Integration Testing
Yes please
<!--
If you spent the time to do some integration testing please link to the pipelines/workflows demonstrating this functionality in context.
-->
<!-- Example
* [Everything]()
* [Typical]()
* [Minimal]()
-->
