### PR TITLE
Changed workflow events so we can more easily test pull requests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,8 @@ on:
     tags:
     - 'v*.*.*'
   pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 env:
   GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
# Purpose
No change to the images. Just making the publish workflow trigger for PRs (which it used to do). Also adding the ability to manually kick of a workflow.

# Breaking?
No

<!-- If YES, uncomment this
## Whats Breaking and why?
-->
<!--
If this change breaks anything, whether by removing functionality/api or changing the default behavior/configuraiton of existing fucntionality/api,
then please list out what will break and why its worth it.
-->

# Integration Testing
<!--
If you spent the time to do some integration testing please link to the pipelines/workflows demonstrating this functionality in context.
-->
<!-- Example
* [Everything]()
* [Typical]()
* [Minimal]()
-->
