### PR TITLE
Adding Containerfiles for Gradle 8.8

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1519,6 +1519,327 @@ jobs:
         run: echo ${{ steps.image_build.outputs.digest }}
 
   #################################
+  # ploigos-tool-gradle_java8_ubi8 #
+  #################################
+  ploigos-tool-gradle_java8_ubi8:
+    needs:
+    - ploigos-tool-java_java8_ubi8
+
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE_CONTEXT: ./ploigos-tool-gradle
+      IMAGE_FILE: Containerfile.ubi8
+      IMAGE_NAME: ploigos-tool-gradle
+      IMAGE_TAG_LOCAL: localhost:5000/${{ secrets.REGISTRY_REPOSITORY }}/ploigos-tool-gradle:latest.java8.ubi8
+      IMAGE_TAG_FLAVOR: .java8.ubi8
+      IMAGE_IS_DEFAULT_FLAVOR: false
+      BASE_IMAGE_NAME: ploigos-tool-java
+      BASE_IMAGE_VERSION: ${{ needs.ploigos-tool-java_java8_ubi8.outputs.version }}
+
+    services:
+      registry:
+        image: registry:2
+        ports:
+        - 5000:5000
+
+    outputs:
+      version: ${{ steps.prep.outputs.version }}
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3.3.0
+
+      - name: Determine Image Version and Tags ⚙️
+        id: prep
+        run: ${GITHUB_WORKSPACE}/.github/scripts/determine-image-version.sh
+
+      - name: Version 📌
+        run: echo ${{ steps.prep.outputs.version }}
+
+      - name: Image Tags 🏷
+        run: echo ${{ steps.prep.outputs.tags }}
+
+      - name: Set up QEMU 🧰
+        uses: docker/setup-qemu-action@v2.1.0
+
+      - name: Set up Docker Buildx 🧰
+        uses: docker/setup-buildx-action@v2.4.0
+        with:
+          driver-opts: network=host
+
+      - name: Cache Docker layers 🗃
+        uses: actions/cache@v3.2.4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Image 🛠
+        id: image_build
+        uses: docker/build-push-action@v4.0.0
+        env:
+          IMAGE_BUILD_ARGS: BASE_IMAGE=${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}/${{ env.BASE_IMAGE_NAME }}:${{ env.BASE_IMAGE_VERSION }}
+        with:
+          context: ${{ env.IMAGE_CONTEXT }}
+          file: ${{ env.IMAGE_CONTEXT }}/${{ env.IMAGE_FILE }}
+          build-args: ${{ env.IMAGE_BUILD_ARGS }}
+          push: true
+          tags: ${{ env.IMAGE_TAG_LOCAL }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Test Image 🧪
+        run: |
+          echo "Verify java installed"
+          docker run -u 1001 ${{ env.IMAGE_TAG_LOCAL }} java -version
+
+          echo "Verify gradle installed"
+          docker run -u 1001  ${{ env.IMAGE_TAG_LOCAL }} gradle -v
+
+      - name: Login to External Registry 🔑
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ secrets.REGISTRY_URI }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push to External Registry 🔺
+        id: push
+        run: |
+          docker pull ${{ env.IMAGE_TAG_LOCAL }}
+
+          TAGS=${{ steps.prep.outputs.tags }}
+          for TAG in ${TAGS//,/ }; do
+            docker tag ${{ env.IMAGE_TAG_LOCAL }} ${TAG}
+            docker push ${TAG}
+          done
+
+      - name: Image Digest 🔖
+        run: echo ${{ steps.image_build.outputs.digest }}
+
+  ##################################
+  # ploigos-tool-gradle_java11_ubi8 #
+  ##################################
+  ploigos-tool-gradle_java11_ubi8:
+    needs:
+    - ploigos-tool-java_java11_ubi8
+
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE_CONTEXT: ./ploigos-tool-gradle
+      IMAGE_FILE: Containerfile.ubi8
+      IMAGE_NAME: ploigos-tool-gradle
+      IMAGE_TAG_LOCAL: localhost:5000/${{ secrets.REGISTRY_REPOSITORY }}/ploigos-tool-gradle:latest.java11.ubi8
+      IMAGE_TAG_FLAVOR: .java11.ubi8
+      IMAGE_IS_DEFAULT_FLAVOR: true
+      BASE_IMAGE_NAME: ploigos-tool-java
+      BASE_IMAGE_VERSION: ${{ needs.ploigos-tool-java_java11_ubi8.outputs.version }}
+
+    services:
+      registry:
+        image: registry:2
+        ports:
+        - 5000:5000
+
+    outputs:
+      version: ${{ steps.prep.outputs.version }}
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3.3.0
+
+      - name: Determine Image Version and Tags ⚙️
+        id: prep
+        run: ${GITHUB_WORKSPACE}/.github/scripts/determine-image-version.sh
+
+      - name: Version 📌
+        run: echo ${{ steps.prep.outputs.version }}
+
+      - name: Image Tags 🏷
+        run: echo ${{ steps.prep.outputs.tags }}
+
+      - name: Set up QEMU 🧰
+        uses: docker/setup-qemu-action@v2.1.0
+
+      - name: Set up Docker Buildx 🧰
+        uses: docker/setup-buildx-action@v2.4.0
+        with:
+          driver-opts: network=host
+
+      - name: Cache Docker layers 🗃
+        uses: actions/cache@v3.2.4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Image 🛠
+        id: image_build
+        uses: docker/build-push-action@v4.0.0
+        env:
+          IMAGE_BUILD_ARGS: BASE_IMAGE=${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}/${{ env.BASE_IMAGE_NAME }}:${{ env.BASE_IMAGE_VERSION }}
+        with:
+          context: ${{ env.IMAGE_CONTEXT }}
+          file: ${{ env.IMAGE_CONTEXT }}/${{ env.IMAGE_FILE }}
+          build-args: ${{ env.IMAGE_BUILD_ARGS }}
+          push: true
+          tags: ${{ env.IMAGE_TAG_LOCAL }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Test Image 🧪
+        run: |
+          echo "Verify java installed"
+          docker run -u 1001 ${{ env.IMAGE_TAG_LOCAL }} java -version
+
+          echo "Verify gradle installed"
+          docker run -u 1001  ${{ env.IMAGE_TAG_LOCAL }} gradle -v
+
+      - name: Login to External Registry 🔑
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ secrets.REGISTRY_URI }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push to External Registry 🔺
+        id: push
+        run: |
+          docker pull ${{ env.IMAGE_TAG_LOCAL }}
+
+          TAGS=${{ steps.prep.outputs.tags }}
+          for TAG in ${TAGS//,/ }; do
+            docker tag ${{ env.IMAGE_TAG_LOCAL }} ${TAG}
+            docker push ${TAG}
+          done
+
+      - name: Image Digest 🔖
+        run: echo ${{ steps.image_build.outputs.digest }}
+
+  ##################################
+  # ploigos-tool-gradle_java17_ubi8 #
+  ##################################
+  ploigos-tool-gradle_java17_ubi8:
+    needs:
+    - ploigos-tool-java_java17_ubi8
+
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE_CONTEXT: ./ploigos-tool-gradle
+      IMAGE_FILE: Containerfile.ubi8
+      IMAGE_NAME: ploigos-tool-gradle
+      IMAGE_TAG_LOCAL: localhost:5000/${{ secrets.REGISTRY_REPOSITORY }}/ploigos-tool-gradle:latest.java17.ubi8
+      IMAGE_TAG_FLAVOR: .java17.ubi8
+      IMAGE_IS_DEFAULT_FLAVOR: false
+      BASE_IMAGE_NAME: ploigos-tool-java
+      BASE_IMAGE_VERSION: ${{ needs.ploigos-tool-java_java17_ubi8.outputs.version }}
+
+    services:
+      registry:
+        image: registry:2
+        ports:
+        - 5000:5000
+
+    outputs:
+      version: ${{ steps.prep.outputs.version }}
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3.3.0
+
+      - name: Determine Image Version and Tags ⚙️
+        id: prep
+        run: ${GITHUB_WORKSPACE}/.github/scripts/determine-image-version.sh
+
+      - name: Version 📌
+        run: echo ${{ steps.prep.outputs.version }}
+
+      - name: Image Tags 🏷
+        run: echo ${{ steps.prep.outputs.tags }}
+
+      - name: Set up QEMU 🧰
+        uses: docker/setup-qemu-action@v2.1.0
+
+      - name: Set up Docker Buildx 🧰
+        uses: docker/setup-buildx-action@v2.4.0
+        with:
+          driver-opts: network=host
+
+      - name: Cache Docker layers 🗃
+        uses: actions/cache@v3.2.4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Image 🛠
+        id: image_build
+        uses: docker/build-push-action@v4.0.0
+        env:
+          IMAGE_BUILD_ARGS: BASE_IMAGE=${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}/${{ env.BASE_IMAGE_NAME }}:${{ env.BASE_IMAGE_VERSION }}
+        with:
+          context: ${{ env.IMAGE_CONTEXT }}
+          file: ${{ env.IMAGE_CONTEXT }}/${{ env.IMAGE_FILE }}
+          build-args: ${{ env.IMAGE_BUILD_ARGS }}
+          push: true
+          tags: ${{ env.IMAGE_TAG_LOCAL }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Test Image 🧪
+        run: |
+          echo "Verify java installed"
+          docker run -u 1001 ${{ env.IMAGE_TAG_LOCAL }} java -version
+
+          echo "Verify gradle installed"
+          docker run -u 1001  ${{ env.IMAGE_TAG_LOCAL }} gradle -v
+
+      - name: Login to External Registry 🔑
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ secrets.REGISTRY_URI }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push to External Registry 🔺
+        id: push
+        run: |
+          docker pull ${{ env.IMAGE_TAG_LOCAL }}
+
+          TAGS=${{ steps.prep.outputs.tags }}
+          for TAG in ${TAGS//,/ }; do
+            docker tag ${{ env.IMAGE_TAG_LOCAL }} ${TAG}
+            docker push ${TAG}
+          done
+
+      - name: Image Digest 🔖
+        run: echo ${{ steps.image_build.outputs.digest }}
+
+  #################################
   # ploigos-tool-jkube_java8_ubi8 #
   #################################
   ploigos-tool-jkube_java8_ubi8:
@@ -4136,6 +4457,114 @@ jobs:
 
           echo "Verify can create file in ~/.m2"
           docker run -u 1001 ${{ env.IMAGE_TAG_LOCAL }} /bin/bash -c "mkdir -p ~/.m2 && touch ~/.m2/test-settings.xml"
+
+      - name: Login to External Registry 🔑
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ secrets.REGISTRY_URI }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push to External Registry 🔺
+        id: push
+        run: |
+          docker pull ${{ env.IMAGE_TAG_LOCAL }}
+
+          TAGS=${{ steps.prep.outputs.tags }}
+          for TAG in ${TAGS//,/ }; do
+            docker tag ${{ env.IMAGE_TAG_LOCAL }} ${TAG}
+            docker push ${TAG}
+          done
+
+      - name: Image Digest 🔖
+        run: echo ${{ steps.image_build.outputs.digest }}
+
+  ##################################
+  # ploigos-tool-gradle_java17_ubi9 #
+  ##################################
+  ploigos-tool-gradle_java17_ubi9:
+    needs:
+    - ploigos-tool-java_java17_ubi9
+
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE_CONTEXT: ./ploigos-tool-gradle
+      IMAGE_FILE: Containerfile.ubi9
+      IMAGE_NAME: ploigos-tool-gradle
+      IMAGE_TAG_LOCAL: localhost:5000/${{ secrets.REGISTRY_REPOSITORY }}/ploigos-tool-gradle:latest.java17.ubi9
+      IMAGE_TAG_FLAVOR: .java17.ubi9
+      IMAGE_IS_DEFAULT_FLAVOR: false
+      BASE_IMAGE_NAME: ploigos-tool-java
+      BASE_IMAGE_VERSION: ${{ needs.ploigos-tool-java_java17_ubi9.outputs.version }}
+
+    services:
+      registry:
+        image: registry:2
+        ports:
+        - 5000:5000
+
+    outputs:
+      version: ${{ steps.prep.outputs.version }}
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3.3.0
+
+      - name: Determine Image Version and Tags ⚙️
+        id: prep
+        run: ${GITHUB_WORKSPACE}/.github/scripts/determine-image-version.sh
+
+      - name: Version 📌
+        run: echo ${{ steps.prep.outputs.version }}
+
+      - name: Image Tags 🏷
+        run: echo ${{ steps.prep.outputs.tags }}
+
+      - name: Set up QEMU 🧰
+        uses: docker/setup-qemu-action@v2.1.0
+
+      - name: Set up Docker Buildx 🧰
+        uses: docker/setup-buildx-action@v2.4.0
+        with:
+          driver-opts: network=host
+
+      - name: Cache Docker layers 🗃
+        uses: actions/cache@v3.2.4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Image 🛠
+        id: image_build
+        uses: docker/build-push-action@v4.0.0
+        env:
+          IMAGE_BUILD_ARGS: BASE_IMAGE=${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}/${{ env.BASE_IMAGE_NAME }}:${{ env.BASE_IMAGE_VERSION }}
+        with:
+          context: ${{ env.IMAGE_CONTEXT }}
+          file: ${{ env.IMAGE_CONTEXT }}/${{ env.IMAGE_FILE }}
+          build-args: ${{ env.IMAGE_BUILD_ARGS }}
+          push: true
+          tags: ${{ env.IMAGE_TAG_LOCAL }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Test Image 🧪
+        run: |
+          echo "Verify java installed"
+          docker run -u 1001 ${{ env.IMAGE_TAG_LOCAL }} java -version
+
+          echo "Verify gradle installed"
+          docker run -u 1001  ${{ env.IMAGE_TAG_LOCAL }} gradle -v
+
 
       - name: Login to External Registry 🔑
         uses: docker/login-action@v2.1.0

--- a/ploigos-tool-gradle/Containerfile
+++ b/ploigos-tool-gradle/Containerfile
@@ -1,0 +1,1 @@
+Containerfile.ubi8

--- a/ploigos-tool-gradle/Containerfile.ubi8
+++ b/ploigos-tool-gradle/Containerfile.ubi8
@@ -1,0 +1,40 @@
+ARG BASE_IMAGE=quay.io/ploigos/ploigos-tool-java-8:latest.ubi8
+ARG GRADLE_VERSION=8.8
+
+FROM $BASE_IMAGE
+ARG PLOIGOS_USER_UID
+ARG PLOIGOS_USER_GID
+ARG GRADLE_VERSION
+
+# labels
+ENV DESCRIPTION="Ploigos tool container with gradle."
+LABEL \
+    maintainer="Ploigos <ploigos@redhat.com>" \
+    name="ploigos/ploigos-tool-gradle" \
+    summary="$DESCRIPTION" \
+    description="$DESCRIPTION" \
+    License="GPLv2+" \
+    architecture="x86_64" \
+    io.k8s.display-name="Ploigos - Tool - gradle" \
+    io.k8s.description="$DESCRIPTION" \
+    io.openshift.expose-services="" \
+    io.openshift.tags="ploigos,gradle" \
+    com.redhat.component="ploigos-tool-gradle-container"
+
+
+USER root
+
+# Install Gradle
+RUN wget -qLO /tmp/gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" && \
+    mkdir /opt/gradle && \
+    unzip -d /opt/gradle /tmp/gradle.zip && \
+    rm /tmp/gradle.zip && \
+    chown -R ${PLOIGOS_USER_UID}:${PLOIGOS_USER_GID} /opt/gradle && \
+    chmod -R ug+wx /opt/gradle
+
+ENV PATH="${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
+
+# may not actually be able to run as this user at runtime
+# but platforms like OpenShift will still respect users home directory
+# so still worth setting
+USER ${PLOIGOS_USER_UID}

--- a/ploigos-tool-gradle/Containerfile.ubi9
+++ b/ploigos-tool-gradle/Containerfile.ubi9
@@ -1,0 +1,40 @@
+ARG BASE_IMAGE=quay.io/ploigos/ploigos-tool-java-8:latest.ubi9
+ARG GRADLE_VERSION=8.8
+
+FROM $BASE_IMAGE
+ARG PLOIGOS_USER_UID
+ARG PLOIGOS_USER_GID
+ARG GRADLE_VERSION
+
+# labels
+ENV DESCRIPTION="Ploigos tool container with gradle."
+LABEL \
+    maintainer="Ploigos <ploigos@redhat.com>" \
+    name="ploigos/ploigos-tool-gradle" \
+    summary="$DESCRIPTION" \
+    description="$DESCRIPTION" \
+    License="GPLv2+" \
+    architecture="x86_64" \
+    io.k8s.display-name="Ploigos - Tool - gradle" \
+    io.k8s.description="$DESCRIPTION" \
+    io.openshift.expose-services="" \
+    io.openshift.tags="ploigos,gradle" \
+    com.redhat.component="ploigos-tool-gradle-container"
+
+
+USER root
+
+# Install Gradle
+RUN wget -qLO /tmp/gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" && \
+    mkdir /opt/gradle && \
+    unzip -d /opt/gradle /tmp/gradle.zip && \
+    rm /tmp/gradle.zip && \
+    chown -R ${PLOIGOS_USER_UID}:${PLOIGOS_USER_GID} /opt/gradle && \
+    chmod -R ug+wx /opt/gradle
+
+ENV PATH="${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
+
+# may not actually be able to run as this user at runtime
+# but platforms like OpenShift will still respect users home directory
+# so still worth setting
+USER ${PLOIGOS_USER_UID}

--- a/ploigos-tool-gradle/README.md
+++ b/ploigos-tool-gradle/README.md
@@ -1,0 +1,7 @@
+# ploigos-tool-gradle
+
+This repository contains the container definition for creating the Ploigos workflow
+[Gradle](https://gradle.org/) CLI tool container image.
+
+This container image is intended to be used as the container image to run Ploigos workflow steps
+in that require access to the [Gradle](https://gradle.org/) CLI tool.


### PR DESCRIPTION
# Purpose
New Feature:  Adding Containerfile for an image with Gradle build tool. This is primary used to support Scala apps that are built with Gradle. Version 8.8 of Gradle is used.

# Breaking?
No

<!-- If YES, uncomment this
## Whats Breaking and why?
-->
<!--
If this change breaks anything, whether by removing functionality/api or changing the default behavior/configuraiton of existing fucntionality/api,
then please list out what will break and why its worth it.
-->

# Integration Testing
This Containerfile was built and tested within an OpenShift 4.12 environment. Below is snippet from the OpenShift build that installs Gradle. 
```
--> 0a1b5a1399c
STEP 12/17: RUN wget -qLO /tmp/gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" &&     mkdir /opt/gradle &&     unzip -d /opt/gradle /tmp/gradle.zip &&     rm /tmp/gradle.zip &&     chown -R ${PLOIGOS_USER_UID}:${PLOIGOS_USER_GID} /opt/gradle &&     chmod -R ug+wx /opt/gradle
Archive:  /tmp/gradle.zip
   creating: /opt/gradle/gradle-8.8/
  <TRUNCATED FOR BREVITY>
--> 6cbd18a06ed
STEP 13/17: ENV PATH="${PATH}:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
--> 0a5f6e32c9a
```
The ploigos-tool-gradle was then tested with modified PSR steps that calls the Gradle CLI. 

Below is a snippet from the PSR step calling unit-tests:

```
    --------------------------------------------------------------------------------
                         Standard Out - unit-test (GradleTest)                      
    --------------------------------------------------------------------------------
        Run unit tests
        
        Welcome to Gradle 8.8!
        
        Here are the highlights of this release:
         - Running Gradle on Java 22
         - Configurable Gradle daemon JVM
         - Improved IDE performance for large projects
        
        For more details see https://docs.gradle.org/8.8/release-notes.html
        
        Starting a Gradle Daemon (subsequent builds will be faster)
        > Task :app:compileJava
        > Task :app:processResources
        > Task :app:classes
        > Task :app:compileTestJava
        > Task :app:processTestResources NO-SOURCE
        > Task :app:testClasses
        > Task :app:test
        
        Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
        
        You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
        
        For more on this, please refer to https://docs.gradle.org/8.8/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
        
        BUILD SUCCESSFUL in 57s
        4 actionable tasks: 4 executed
```


