### PR TITLE
Fix  ploigos-tool-autogov build (Download GoLang and install)

### DIFF
--- a/ploigos-tool-autogov/Containerfile.ubi8
+++ b/ploigos-tool-autogov/Containerfile.ubi8
@@ -1,11 +1,13 @@
 ARG BASE_IMAGE=quay.io/ploigos/ploigos-base:latest.ubi8
 ARG REKOR_VERSION=e63fe717c810657c270edfb964aef10969e7f210
 ARG OPA_VERSION=v0.29.4
+ARG GOLANG_VERSION=1.22.4
 
 FROM $BASE_IMAGE
 ARG PLOIGOS_USER_UID
 ARG REKOR_VERSION
 ARG OPA_VERSION
+ARG GOLANG_VERSION
 
 # labels
 ENV DESCRIPTION="Ploigos tool container with Rekor and Open Policy Agent."
@@ -27,15 +29,13 @@ ENV LANG=en_US.UTF-8 \
 
 USER root
 
-# Copy the entrypoint
-ADD contrib/centos.repo /etc/yum.repos.d/
+# Install GoLang
+RUN curl -L https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz -o /tmp/golang.tar.gz && \
+    tar -C /usr/local -xzf /tmp/golang.tar.gz
 
-# update and install packages
-RUN INSTALL_PKGS="golang" && \
-    dnf update -y --allowerasing --nobest && \
-    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    dnf clean all && \
-    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+ENV PATH=$PATH:/usr/local/go/bin
+ENV GOPATH=$HOME/go
+ENV PATH=$PATH:$GOPATH/bin
 
 # Install rekor
 # NOTE: better way to install, except as of 7/21/21 only v0.2.0 is released and it doesnt work with PSR

--- a/ploigos-tool-autogov/contrib/centos.repo
+++ b/ploigos-tool-autogov/contrib/centos.repo
@@ -1,5 +1,0 @@
-[centos] 
-name=centos
-baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os
-enabled=1 
-gpgcheck=0


### PR DESCRIPTION
# Purpose
PR to fix the ploigos-tool-autogov image. The old image attempts to fetch and install golang via deprecated CentOS repo. The new approach is to download golang and install. 

# Breaking?
No


# Integration Testing

Here is a successful build (with some debug RUN statements to get the go version):
```
STEP 10/20: RUN curl -L https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz -o /tmp/golang.tar.gz && tar -C /usr/local -xzf /tmp/golang.tar.gz
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
% Total % Received % Xferd Average Speed Time Time Time Current
Dload Upload Total Spent Left Speed
0 0 0 0 0 0 0 0 --:--:-- --:--:-- --:--:-- 0100 75 100 75 0 0 619 0 --:--:-- --:--:-- --:--:-- 619
83 65.7M 83 55.0M 0 0 123M 0 --:--:-- --:--:-- --:--:-- 123M100 65.7M 100 65.7M 0 0 132M 0 --:--:-- --:--:-- --:--:-- 209M
--> a5b72fa59a8
STEP 11/20: ENV PATH=$PATH:/usr/local/go/bin
--> 31eeb158087
STEP 12/20: ENV GOPATH=$HOME/go
--> a0cdab86bc4
STEP 13/20: ENV PATH=$PATH:$GOPATH/bin
--> 42a88dc6833
STEP 14/20: RUN which go
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
/usr/local/go/bin/go
--> 98c20fc69f9
STEP 15/20: RUN go version
/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
go version go1.22.4 linux/amd64
```

Additionally, the autogov image locally was able to use go to build rekor successfully.